### PR TITLE
Use Cronner to monitor backup cronjob

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,4 @@ source_url 'https://github.com/darkskyapp/ds_chef_server_populator-cookbook' if 
 issues_url 'https://github.com/darkskyapp/ds_chef_server_populator-cookbook/issues' if respond_to?(:issues_url)
 
 depends 'chef-server', '~> 5.0'
+depends 'cronner'

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -47,9 +47,15 @@ template '/usr/local/bin/chef-server-backup' do
   retries 3
 end
 
+execute 'install chef_server_backup gems' do
+  command 'bundle install --path /etc/opscode/.vendor'
+  environment BUNDLE_GEMFILE: '/etc/opscode/Gemfile'
+  path '/opt/chef/embedded/bin:/usr/bin:/usr/local/bin:/bin'
+  creates '/etc/opscode/.vendor'
+end
+
 cron 'Chef Server Backups' do
-  command 'bundle install --path /etc/opscode/.vendor && '\
-          'bundle exec /usr/local/bin/chef-server-backup'
+  command 'bundle exec /usr/local/bin/chef-server-backup'
   node['chef_server_populator']['backup']['schedule'].each do |k, v|
     send(k, v)
   end

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -55,6 +55,13 @@ execute 'install chef_server_backup gems' do
 end
 
 cron 'Chef Server Backups' do
+  action :delete
+end
+
+include_recipe 'cronner'
+
+cronner 'chef_server_backup' do
+  event true
   command 'bundle exec /usr/local/bin/chef-server-backup'
   node['chef_server_populator']['backup']['schedule'].each do |k, v|
     send(k, v)


### PR DESCRIPTION
[cronner](https://github.com/theckman/cronner) is a cronjob runner that reports its runs via DogStatsd.

Fixes darkskyapp/infrastructure#258